### PR TITLE
乱数生成用の `/dev/urandom` のFDを使い回す

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ FILES	:=	\
 			utils_endian.c\
 			utils_error.c\
 			utils_print.c\
+			utils_random.c\
 			printf.c\
 			option_parser.c\
 

--- a/includes/ft_ssl_des_internal.h
+++ b/includes/ft_ssl_des_internal.h
@@ -106,8 +106,6 @@ void			des_bytes_from_hex(const char* hex, uint8_t* out, size_t size);
 // 鍵材料 (8 オクテット × count) からラウンド鍵一式を作る.
 t_des_keys		des_keys_from_bytes(const uint8_t* material, size_t count);
 
-// salt をランダムに生成する.
-bool			des_random_salt(uint8_t salt[DES_SALT_BYTE_SIZE]);
 // パスワードと salt から鍵材料と IV を導出する (PBKDF2-HMAC-SHA256).
 // 導出結果は先頭 key_byte_size オクテットが鍵材料, 続く 8 オクテットが IV.
 bool			des_derive_key_iv(

--- a/includes/ft_ssl_lib.h
+++ b/includes/ft_ssl_lib.h
@@ -19,6 +19,9 @@
 // utils_print.c
 bool	write_all(int fd, const void* data, size_t len);
 
+// utils_random.c
+bool	random_bytes(void* out, size_t size);
+
 // subbyte_manipulation.c
 void	set_bit_at(uint8_t* mem, uint64_t bit_pos, uint8_t bit);
 void	subbyte_memcpy(uint8_t* dst, const uint8_t* src, uint8_t bit_from, uint8_t bit_to);

--- a/srcs/des.c
+++ b/srcs/des.c
@@ -128,7 +128,7 @@ static bool	resolve_salt(t_master_des* m, t_elastic_buffer* input, t_des_secret*
 		return true;
 	}
 	// ユーザー入力から salt を得られなかったので, 乱数から生成
-	if (!des_random_salt(secret->salt)) {
+	if (!random_bytes(secret->salt, DES_SALT_BYTE_SIZE)) {
 		PRINT_ERROR(&m->master, "%s\n", "unable to generate salt");
 		return false;
 	}

--- a/srcs/des_key.c
+++ b/srcs/des_key.c
@@ -61,25 +61,6 @@ t_des_keys	des_keys_from_bytes(const uint8_t* material, size_t count) {
 	return keys;
 }
 
-bool	des_random_salt(uint8_t salt[DES_SALT_BYTE_SIZE]) {
-	const int	fd = open("/dev/urandom", O_RDONLY);
-	if (fd < 0) {
-		return false;
-	}
-	size_t	got = 0;
-	while (got < DES_SALT_BYTE_SIZE) {
-		 // urandom から擬似**ではない**乱数を生成する
-		const ssize_t	n = read(fd, salt + got, DES_SALT_BYTE_SIZE - got);
-		if (n <= 0) {
-			close(fd);
-			return false;
-		}
-		got += n;
-	}
-	close(fd);
-	return true;
-}
-
 bool	des_derive_key_iv(
 	const char* password,
 	const uint8_t salt[DES_SALT_BYTE_SIZE],

--- a/srcs/utils_random.c
+++ b/srcs/utils_random.c
@@ -1,0 +1,36 @@
+#include "ft_ssl.h"
+
+// [乱数の取得]
+// /dev/urandom から読む. 許可関数 (open / read / close) だけで済み,
+// arc4random や getentropy のような追加シンボルを持ち込まずに
+// 暗号用途に足る乱数が得られる.
+//
+// fd は一度開いたら閉じずに使い回す.
+// RSA の鍵生成は素数が見つかるまで候補を作り直すので, 1 回の genrsa でも
+// 数百回の要求が来る. 要求ごとに開き直すのは無駄なだけでなく,
+// 「最初は開けたのに途中から開けない」という扱いにくい失敗を増やす.
+// プロセスが動いている間ずっと必要なものなので, 意図的に開いたままにする.
+static int	g_urandom_fd = -1;
+
+// out に size オクテットの乱数を書く. 全部書けたときだけ true.
+// (失敗の報告は呼び出し側が行う; ここは用途を知らないのでメッセージを持てない)
+bool	random_bytes(void* out, size_t size) {
+	if (g_urandom_fd < 0) {
+		g_urandom_fd = open("/dev/urandom", O_RDONLY);
+		if (g_urandom_fd < 0) {
+			return false;
+		}
+	}
+
+	uint8_t*	head = out;
+	while (size > 0) {
+		const ssize_t	n = read(g_urandom_fd, head, size);
+		// urandom で 0 が返ることはないが, 進まないまま回り続けないよう失敗にする
+		if (n <= 0) {
+			return false;
+		}
+		head += n;
+		size -= (size_t)n;
+	}
+	return true;
+}

--- a/test/des_properties.sh
+++ b/test/des_properties.sh
@@ -10,6 +10,7 @@
 #   3. 準弱鍵の対では互いに打ち消し合う E_K1(E_K2(x)) = x
 #   4. 3DES に同じ鍵を3本与えると単一 DES と一致する
 #   5. CTR のカウンタは 2^64 で巻き戻る
+#   6. 乱数取得は同一プロセス内で繰り返し呼んでも毎回違う値を返す
 #
 # 前提: プロジェクトルートで ./ft_ssl をビルド済みであること.
 # 使い方: bash test/des_properties.sh
@@ -99,6 +100,38 @@ actual=$("$SSL" des-ctr -k "$K" -v ffffffffffffffff -i "$TMP/zero16" | od -An -t
 # 平文が全 0 なので, 出力はそのまま鍵ストリーム E(カウンタ) になる
 expected="$(encrypt_block "$K" ffffffffffffffff)$(encrypt_block "$K" 0000000000000000)"
 expect "カウンタ ffffffffffffffff の次が 0 になる" "$actual" "$expected"
+
+echo "--- 6. 乱数取得は同一プロセス内で繰り返しても毎回変わる ---"
+# random_bytes (srcs/utils_random.c) は /dev/urandom の fd を開いたまま使い回す.
+# REPL は 1 プロセスで複数コマンドを走らせるので, 2 回目以降も正しく読めているかを
+# ここで確かめる. des_mode.sh の同種の検査はプロセスを分けて呼ぶため, この経路は通らない.
+# salt は "Salted__"(8) の直後の 8 バイト.
+salt_of() { # salt_of <暗号文ファイル>
+	head -c 16 "$1" | tail -c 8 | od -An -tx1 | tr -d ' \n'
+}
+# salt_of は改行を付けないので, 数え上げる側で行に分ける.
+# (付けないまま sort -u に渡すと全部が 1 行に繋がり, 常に「1 種」になって素通りする)
+count_distinct_salts() { # count_distinct_salts <暗号文ファイル...>
+	for f in "$@"; do
+		salt_of "$f"
+		echo
+	done | sort -u | wc -l | tr -d ' '
+}
+write_hex "$PLAIN" "$TMP/msg8"
+for i in 1 2 3; do echo "des-ecb -p pw -i $TMP/msg8 -o $TMP/salt_run$i"; done \
+	| "$SSL" >/dev/null 2>&1
+expect "REPL 内 3 回で salt が 3 種" \
+	"$(count_distinct_salts "$TMP/salt_run1" "$TMP/salt_run2" "$TMP/salt_run3")" "3"
+# 全ゼロなら, open の失敗を見逃して未初期化のまま進んでいる疑いがある
+expect "salt が全ゼロでない" \
+	"$([ "$(salt_of "$TMP/salt_run1")" = "0000000000000000" ] && echo zero || echo nonzero)" "nonzero"
+# 陰性対照: -s で salt を固定すれば 3 回とも一致する.
+# (これが 3 種になるなら, 上の検査は salt ではない何かを見ている)
+for i in 1 2 3; do echo "des-ecb -p pw -s 8877665544332211 -i $TMP/msg8 -o $TMP/fixed_run$i"; done \
+	| "$SSL" >/dev/null 2>&1
+expect "陰性対照: -s 指定なら 1 種" \
+	"$(count_distinct_salts "$TMP/fixed_run1" "$TMP/fixed_run2" "$TMP/fixed_run3")" "1"
+expect "陰性対照: -s の値がそのまま入る" "$(salt_of "$TMP/fixed_run1")" "8877665544332211"
 
 echo
 echo "=== des_properties: pass=$pass fail=$fail ==="


### PR DESCRIPTION
乱数を引くたびに`open`していてもったいなかった。